### PR TITLE
Redirect to the previous url upon signing in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_filter :store_current_location, :unless => :devise_controller?
 
   def authenticate_admin_user!
     if current_user
@@ -13,4 +14,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  private
+
+  def store_current_location
+    store_location_for(:user, request.url)
+  end
 end


### PR DESCRIPTION
This PR is based on #10 and provides a fix (that was not straightforward to find/implement) to devise redirection upon sign-in. It's meant and already setup to be merged in the `active-admin` branch.
